### PR TITLE
Fix Github Actions Warnings

### DIFF
--- a/.github/workflows/AutoApiSuper.yml
+++ b/.github/workflows/AutoApiSuper.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.repository.owner.id == github.event.sender.id  # 自己点的 start
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: Set up Python #安装python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/randomapi.yml
+++ b/.github/workflows/randomapi.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.repository.owner.id == github.event.sender.id  # 自己点的 start
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: Set up Python #安装python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/uaptetoken.yml
+++ b/.github/workflows/uaptetoken.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: Set up Python #安装python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
> The "master" branch is no longer the default branch name for actions/checkout
> Please pin to a specific version or use "main".
It is displayed on the running interface.

I have tested it on [my own task](https://github.com/xqymain/RenewMircosoftE5/).

In order to ensure normal operation in the future, create this pull request :)